### PR TITLE
活動時間(active_time)モデルとその管理機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "devise"
 # gem "image_processing", "~> 1.2"
 gem "rails-i18n", "~> 7.0"
 gem "devise-i18n"
+gem "sassc-rails"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,14 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -295,6 +303,14 @@ GEM
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     securerandom (0.4.1)
     selenium-webdriver (4.33.0)
       base64 (~> 0.2)
@@ -314,6 +330,7 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.7)
     thor (1.3.2)
+    tilt (2.6.0)
     timeout (0.4.3)
     turbo-rails (2.0.13)
       actionpack (>= 7.1.0)
@@ -368,6 +385,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-rails-omakase
+  sassc-rails
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/assets/stylesheets/active_times.scss
+++ b/app/assets/stylesheets/active_times.scss
@@ -1,0 +1,25 @@
+.ActiveTime {
+  display: flex;
+  gap: 2rem; // 左右の余白
+
+  &__list {
+    width: 40%;
+    background-color: #f9f9f9;
+    padding: 1rem;
+    border-radius: 0.5rem;
+  }
+
+  &__editor {
+    width: 60%;
+    background-color: #fff;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
+  }
+
+  &__heading {
+    font-size: 1.25rem;
+    font-weight: bold;
+    margin-bottom: 1rem;
+  }
+}

--- a/app/controllers/active_times_controller.rb
+++ b/app/controllers/active_times_controller.rb
@@ -2,7 +2,7 @@ class ActiveTimesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_active_time, only: [ :update ]
   before_action :ensure_owner, only: [ :update ]
-  before_action :set_active_times, only: [:index, :update]
+  before_action :set_active_times, only: [ :index, :update ]
 
   def index
     if params[:edit_id].present?

--- a/app/controllers/active_times_controller.rb
+++ b/app/controllers/active_times_controller.rb
@@ -18,7 +18,7 @@ class ActiveTimesController < ApplicationController
     if @active_time.update(active_time_params)
       redirect_to active_time_path, notice: "活動時間を更新しました"
     else
-      flash.now[ :alert ] = "更新に失敗しました。"
+      flash.now[:alert] = "更新に失敗しました。"
       render :index
     end
   end
@@ -28,7 +28,7 @@ class ActiveTimesController < ApplicationController
   end
 
   def ensure_owner
-    redirect_to root_path, alert: 'アクセスできません' unless @active_time.user == current_user
+    redirect_to root_path, alert: "アクセスできません" unless @active_time.user == current_user
   end
 
   def active_time_params

--- a/app/controllers/active_times_controller.rb
+++ b/app/controllers/active_times_controller.rb
@@ -1,2 +1,37 @@
 class ActiveTimesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_active_time, only: [ :edit, :update ]
+  before_action :ensure_owner, only: [ :edit, :update ]
+
+  def index
+    @active_times = current_user.active_times.order(:day_of_week)
+
+    if params[:edit_id].present?
+      @editing_active_time = current_user.active_times.find_by(id: params[:edit_id])
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @active_time.update(active_time_params)
+      redirect_to active_time_path, notice: "活動時間を更新しました"
+    else
+      flash.now[ :alert ] = "更新に失敗しました。"
+      render :index
+    end
+  end
+
+  def set_active_time
+    @active_time = ActiveTime.find(params[:id])
+  end
+
+  def ensure_owner
+    redirect_to root_path, alert: 'アクセスできません' unless @active_time.user == current_user
+  end
+
+  def active_time_params
+    params.require(:active_time).permit(:day_of_week, :start_time, :end_time, :granularity_minutes)
+  end
 end

--- a/app/controllers/active_times_controller.rb
+++ b/app/controllers/active_times_controller.rb
@@ -1,30 +1,31 @@
 class ActiveTimesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_active_time, only: [ :edit, :update ]
-  before_action :ensure_owner, only: [ :edit, :update ]
+  before_action :set_active_time, only: [ :update ]
+  before_action :ensure_owner, only: [ :update ]
+  before_action :set_active_times, only: [:index, :update]
 
   def index
-    @active_times = current_user.active_times.order(:day_of_week)
-
     if params[:edit_id].present?
       @editing_active_time = current_user.active_times.find_by(id: params[:edit_id])
     end
-  end
-
-  def edit
   end
 
   def update
     if @active_time.update(active_time_params)
       redirect_to active_time_path, notice: "活動時間を更新しました"
     else
+      @editing_active_time = @active_time
       flash.now[:alert] = "更新に失敗しました。"
-      render :index
+      render :index, status: :unprocessable_entity
     end
   end
 
   def set_active_time
     @active_time = ActiveTime.find(params[:id])
+  end
+
+  def set_active_times
+    @active_times = current_user.active_times.order(:day_of_week)
   end
 
   def ensure_owner

--- a/app/controllers/active_times_controller.rb
+++ b/app/controllers/active_times_controller.rb
@@ -1,0 +1,2 @@
+class ActiveTimesController < ApplicationController
+end

--- a/app/helpers/active_times_helper.rb
+++ b/app/helpers/active_times_helper.rb
@@ -1,0 +1,2 @@
+module ActiveTimesHelper
+end

--- a/app/helpers/active_times_helper.rb
+++ b/app/helpers/active_times_helper.rb
@@ -1,2 +1,5 @@
 module ActiveTimesHelper
+  def day_label(day_number)
+    %w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日][day_number]
+  end
 end

--- a/app/helpers/active_times_helper.rb
+++ b/app/helpers/active_times_helper.rb
@@ -1,5 +1,5 @@
 module ActiveTimesHelper
   def day_label(day_number)
-    %w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日][day_number]
+    %w[月曜日 火曜日 水曜日 木曜日 金曜日 土曜日 日曜日][day_number]
   end
 end

--- a/app/models/active_time.rb
+++ b/app/models/active_time.rb
@@ -1,3 +1,14 @@
 class ActiveTime < ApplicationRecord
   belongs_to :user
+
+  validates :granularity_minutes, inclusion: { in: [15, 30, 45, 60] }
+  validate :start_time_before_end_time
+
+  private
+
+  def start_time_before_end_time
+    if start_time > end_time
+      errors.add(:start_time, "は終了時間より前にしてください")
+    end
+  end
 end

--- a/app/models/active_time.rb
+++ b/app/models/active_time.rb
@@ -1,0 +1,3 @@
+class ActiveTime < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/active_time.rb
+++ b/app/models/active_time.rb
@@ -8,7 +8,7 @@ class ActiveTime < ApplicationRecord
 
   def start_time_before_end_time
     if start_time > end_time
-      errors.add(:start_time, "は終了時間より前にしてください")
+      errors.add(:start_time, "開始時間は終了時間より前にしてください")
     end
   end
 end

--- a/app/models/active_time.rb
+++ b/app/models/active_time.rb
@@ -1,12 +1,15 @@
 class ActiveTime < ApplicationRecord
   belongs_to :user
 
+  validates :start_time, :end_time, presence: true
   validates :granularity_minutes, inclusion: { in: [ 15, 30, 45, 60 ] }
   validate :start_time_before_end_time
 
   private
 
   def start_time_before_end_time
+    return if start_time.blank? || end_time.blank?
+
     if start_time > end_time
       errors.add(:start_time, "開始時間は終了時間より前にしてください")
     end

--- a/app/models/active_time.rb
+++ b/app/models/active_time.rb
@@ -1,7 +1,7 @@
 class ActiveTime < ApplicationRecord
   belongs_to :user
 
-  validates :granularity_minutes, inclusion: { in: [15, 30, 45, 60] }
+  validates :granularity_minutes, inclusion: { in: [ 15, 30, 45, 60 ] }
   validate :start_time_before_end_time
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
   private
 
   def create_default_active_times
-    (1..5).each do |dow|
+    (0..6).each do |dow|
       active_times.create!(
         day_of_week: dow,
         start_time: "00:00",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,8 +16,8 @@ class User < ApplicationRecord
     (1..5).each do |dow|
       active_times.create!(
         day_of_week: dow,
-        start_time: "09:00",
-        end_time: "17:00",
+        start_time: "00:00",
+        end_time: "23:59",
         granularity_minutes: 30
       )
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :active_times, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -6,4 +7,19 @@ class User < ApplicationRecord
 
   validates :username, presence: true, length: { in: 1..20 }
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  after_create :create_default_active_times
+
+  private
+
+  def create_default_active_times
+    (1..5).each do |dow|
+      active_times.create!(
+        day_of_week: dow,
+        start_time: "09:00",
+        end_time: "17:00",
+        granularity_minutes: 30
+      )
+    end
+  end
 end

--- a/app/views/active_times/index.html.erb
+++ b/app/views/active_times/index.html.erb
@@ -6,7 +6,7 @@
         <li class="ActiveTime__item">
           <% is_editing =  @editing_active_time&.id == active_time.id %>
           <% icon = is_editing ? "▶︎" : "・" %>
-          <%= link_to "#{icon} #{day_label(active_time.day_of_week)} #{active_time.start_time.strftime('%H:%M')} - #{active_time.end_time.strftime('%H:%M')}", active_times_path(edit_id: active_time.id), class: "ActiveTime__link" %>
+          <%= link_to "#{icon} #{day_label(active_time.day_of_week)} #{active_time.start_time.strftime('%H:%M')} - #{active_time.end_time.strftime('%H:%M')} （#{active_time.granularity_minutes}分）", active_times_path(edit_id: active_time.id), class: "ActiveTime__link" %>
         </li>
       <% end %>
     </ul>
@@ -33,7 +33,7 @@
 
         <div class="ActiveTime__form-group">
           <%= f.label :granularity_minutes, "表示時間の間隔(分)" %>
-          <%= f.number_field :granularity_minutes %>
+          <%= f.select :granularity_minutes, options_for_select([[15, "15分"], [30, "30分"], [45, "45分"], [60, "60分"]],  f.object.granularity_minutes), {}, { required: true } %>
         </div>
 
         <div class="ActiveTime__submit">

--- a/app/views/active_times/index.html.erb
+++ b/app/views/active_times/index.html.erb
@@ -1,0 +1,47 @@
+<div class="ActiveTime">
+  <div class="ActiveTime__list">
+    <h2 class="ActiveTime__heading">活動時間 一覧</h2>
+    <ul class="ActiveTime__list-items">
+      <% @active_times.each do |active_time| %>
+        <li class="ActiveTime__item">
+          <% is_editing =  @editing_active_time&.id == active_time.id %>
+          <% icon = is_editing ? "▶︎" : "・" %>
+          <%= link_to "#{icon} #{day_label(active_time.day_of_week)} #{active_time.start_time.strftime('%H:%M')} - #{active_time.end_time.strftime('%H:%M')}", active_times_path(edit_id: active_time.id), class: "ActiveTime__link" %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+
+  <div class="ActiveTime__editor">
+    <% if @editing_active_time %>
+      <h2 class="ActiveTime__heading"><%= day_label(@editing_active_time.day_of_week) %> の編集</h2>
+
+      <div class="ActiveTime__graph">
+        <p><%= day_label(@editing_active_time.day_of_week) %> のグラフ</p>
+      </div>
+
+      <%= form_with model: @editing_active_time, url: active_time_path(@editing_active_time), method: :patch, local: true, html: { class: "ActiveTime__form" } do |f| %>
+        <div class="ActiveTime__form-group">
+          <%= f.label :start_time, '開始時間' %>
+          <%= f.time_field :start_time %>
+        </div>
+
+        <div class="ActiveTime__form-group">
+          <%= f.label :end_time, '終了時間' %>
+          <%= f.time_field :end_time %>
+        </div>
+
+        <div class="ActiveTime__form-group">
+          <%= f.label :granularity_minutes, "表示時間の間隔(分)" %>
+          <%= f.number_field :granularity_minutes %>
+        </div>
+
+        <div class="ActiveTime__submit">
+          <%= f.submit "設定を更新する" %>
+        </div>
+      <% end %>
+    <% else %>
+        <p>左から曜日を選択してください。</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/active_times/index.html.erb
+++ b/app/views/active_times/index.html.erb
@@ -24,6 +24,11 @@
         <div class="ActiveTime__form-group">
           <%= f.label :start_time, '開始時間' %>
           <%= f.time_field :start_time %>
+          <% if @editing_active_time.errors[:start_time].any? %>
+            <div class="ActiveTime__error-message">
+              <%= @editing_active_time.errors[:start_time].join(", ") %>
+            </div>
+          <% end %>
         </div>
 
         <div class="ActiveTime__form-group">

--- a/app/views/active_times/index.html.erb
+++ b/app/views/active_times/index.html.erb
@@ -23,7 +23,7 @@
       <%= form_with model: @editing_active_time, url: active_time_path(@editing_active_time), method: :patch, local: true, html: { class: "ActiveTime__form" } do |f| %>
         <div class="ActiveTime__form-group">
           <%= f.label :start_time, '開始時間' %>
-          <%= f.time_field :start_time %>
+          <%= f.time_field :start_time, required: true %>
           <% if @editing_active_time.errors[:start_time].any? %>
             <div class="ActiveTime__error-message">
               <%= @editing_active_time.errors[:start_time].join(", ") %>
@@ -33,7 +33,7 @@
 
         <div class="ActiveTime__form-group">
           <%= f.label :end_time, '終了時間' %>
-          <%= f.time_field :end_time %>
+          <%= f.time_field :end_time, required: true %>
         </div>
 
         <div class="ActiveTime__form-group">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,6 +26,7 @@
         <% if user_signed_in? %>
           ログイン中：<%= current_user.username %>
           <%= link_to "ホーム", root_path %> |
+          <%= link_to "活動時間を設定", active_times_path %> |
           <%= link_to "ユーザー情報編集", edit_user_registration_path %> |
           <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
           <%= button_to "アカウント削除", registration_path(:user), method: :delete, data: { confirm: "本当にアカウントを削除しますか？" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   get "home/index"
   root "home#index"
   devise_for :users
-  resources :active_times, only: [ :index, :edit, :update ]
+  resources :active_times, only: [ :index, :update ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   get "home/index"
   root "home#index"
   devise_for :users
-  resources :active_times, only: [:index, :edit, :update]
+  resources :active_times, only: [ :index, :edit, :update ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   get "home/index"
   root "home#index"
   devise_for :users
+  resources :active_times, only: [:index, :edit, :update]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250604225741_create_active_times.rb
+++ b/db/migrate/20250604225741_create_active_times.rb
@@ -1,0 +1,13 @@
+class CreateActiveTimes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :active_times do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :day_of_week, null: false
+      t.time :start_time, null: false
+      t.time :end_time, null: false
+      t.integer :granularity_minutes, null: false, default: 30
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_31_093857) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_04_225741) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_times", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "day_of_week", null: false
+    t.time "start_time", null: false
+    t.time "end_time", null: false
+    t.integer "granularity_minutes", default: 30, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_active_times_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +37,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_31_093857) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "active_times", "users"
 end

--- a/spec/factories/active_times.rb
+++ b/spec/factories/active_times.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :active_time do
+    user { nil }
+    day_of_week { 1 }
+    start_time { "2025-06-05 07:57:41" }
+    end_time { "2025-06-05 07:57:41" }
+    granularity_minutes { 1 }
+  end
+end

--- a/spec/factories/active_times.rb
+++ b/spec/factories/active_times.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :active_time do
-    user { nil }
-    day_of_week { 1 }
-    start_time { "2025-06-05 07:57:41" }
-    end_time { "2025-06-05 07:57:41" }
-    granularity_minutes { 1 }
+    association :user
+    day_of_week { rand(1..5) }
+    start_time { "00:00" }
+    end_time { "23:59" }
+    granularity_minutes { 30 }
   end
 end

--- a/spec/helpers/active_times_helper_spec.rb
+++ b/spec/helpers/active_times_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ActiveTimesHelper. For example:
+#
+# describe ActiveTimesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ActiveTimesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/active_time_spec.rb
+++ b/spec/models/active_time_spec.rb
@@ -1,5 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe ActiveTime, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+
+  describe "バリデーション" do
+    it "有効なデータの時は通る" do
+      active_time = build(:active_time, user: user)
+      expect(active_time).to be_valid
+    end
+
+    it "開始時間が終了時間より後の場合なら無効" do
+      active_time = build(:active_time, user: user, start_time: "10:00", end_time: "09:00")
+      expect(active_time).to_not be_valid
+      expect(active_time.errors[:start_time]).to include("は終了時間より前にしてください")
+    end
+
+    it '粒度が不正なら無効' do
+      active_time = build(:active_time, user: user, granularity_minutes: 10)
+      expect(active_time).to_not be_valid
+    end
+
+    it "ユーザーに属している必要がある" do
+      active_time = build(:active_time, user: nil)
+      expect(active_time).not_to be_valid
+    end
+  end
 end

--- a/spec/models/active_time_spec.rb
+++ b/spec/models/active_time_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe ActiveTime, type: :model do
       expect(active_time).to be_valid
     end
 
+    it "開始時間がnuilだと無効" do
+      active_time = build(:active_time, start_time: nil)
+      expect(active_time).to_not be_valid
+    end
+
+    it "終了時間がnilだと無効" do
+      active_time = build(:active_time, end_time: nil)
+      expect(active_time).to_not be_valid
+    end
+
     it "開始時間が終了時間より後の場合なら無効" do
       active_time = build(:active_time, user: user, start_time: "10:00", end_time: "09:00")
       expect(active_time).to_not be_valid
@@ -22,7 +32,7 @@ RSpec.describe ActiveTime, type: :model do
 
     it "ユーザーに属している必要がある" do
       active_time = build(:active_time, user: nil)
-      expect(active_time).not_to be_valid
+      expect(active_time).to_not be_valid
     end
   end
 end

--- a/spec/models/active_time_spec.rb
+++ b/spec/models/active_time_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ActiveTime, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/active_time_spec.rb
+++ b/spec/models/active_time_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ActiveTime, type: :model do
     it "開始時間が終了時間より後の場合なら無効" do
       active_time = build(:active_time, user: user, start_time: "10:00", end_time: "09:00")
       expect(active_time).to_not be_valid
-      expect(active_time.errors[:start_time]).to include("は終了時間より前にしてください")
+      expect(active_time.errors[:start_time]).to include("開始時間は終了時間より前にしてください")
     end
 
     it '粒度が不正なら無効' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,5 +36,10 @@ RSpec.describe User, type: :model do
       expect(user).to be_invalid
       expect(user.errors[:password_confirmation]).to include('とパスワードの入力が一致しません')
     end
+
+    it "ユーザー作成時に7件の活動時間が自動生成される" do
+      user = create(:user)
+      expect(user.active_times.count).to eq(7)
+    end
   end
 end

--- a/spec/requests/active_times_spec.rb
+++ b/spec/requests/active_times_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "ActiveTimes", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
###以下の内容を追加しました
1.active_timeモデルの追加
2.ユーザー作成時に自動でactive_timeが曜日分生成される機能の実装
3.活動時間の一覧および編集を行うビューの追加
4.active_timeのコントローラーの追加
5.active_timeコントローラーにupdate/indexのアクション追加して,活動時間の表示と編集機能を実装
6.active_timeモデルにバリデーション(時間の整合制,必須,間隔の必須選択化)の追加
7.active_timeのモデルスペックの追加